### PR TITLE
Add basic main menu and progress tracking

### DIFF
--- a/Assets/Scenes/Instructions.unity
+++ b/Assets/Scenes/Instructions.unity
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1
+GameObject:
+  m_Name: Instructions
+  m_EditorHideFlags: 0
+  m_Component:
+  - component: {fileID: 2}
+  m_Layer: 0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+--- !u!4 &2
+Transform:
+  m_GameObject: {fileID: 1}
+SceneRoots:
+  m_Roots:
+  - {fileID: 1}

--- a/Assets/Scenes/Instructions.unity.meta
+++ b/Assets/Scenes/Instructions.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2252306f033048dca8ab58516f9a50cd
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scenes/MainMenu.unity
+++ b/Assets/Scenes/MainMenu.unity
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1
+GameObject:
+  m_Name: MainMenu
+  m_EditorHideFlags: 0
+  m_Component:
+  - component: {fileID: 2}
+  m_Layer: 0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+--- !u!114 &2
+MonoBehaviour:
+  m_GameObject: {fileID: 1}
+  m_Enabled: 1
+  m_Script: {fileID: 11500000, guid: 2730e15a880541598297e5b1170e4727, type: 3}
+  m_Name: MenuManager
+SceneRoots:
+  m_Roots:
+  - {fileID: 1}

--- a/Assets/Scenes/MainMenu.unity.meta
+++ b/Assets/Scenes/MainMenu.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e67e1f6c5bd247129422df0d176c7e63
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scenes/Settings.unity
+++ b/Assets/Scenes/Settings.unity
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1
+GameObject:
+  m_Name: Settings
+  m_EditorHideFlags: 0
+  m_Component:
+  - component: {fileID: 2}
+  m_Layer: 0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+--- !u!4 &2
+Transform:
+  m_GameObject: {fileID: 1}
+SceneRoots:
+  m_Roots:
+  - {fileID: 1}

--- a/Assets/Scenes/Settings.unity.meta
+++ b/Assets/Scenes/Settings.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f1a937f1fc7f48dcb3fcfa7972d421ac
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/GameSettings.cs
+++ b/Assets/Scripts/GameSettings.cs
@@ -1,0 +1,27 @@
+using UnityEngine;
+
+public enum Difficulty
+{
+    Easy,
+    Normal,
+    Hard
+}
+
+public class GameSettings : MonoBehaviour
+{
+    public static GameSettings Instance { get; private set; }
+
+    public Difficulty difficulty = Difficulty.Normal;
+    public string selectedMap;
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
+    }
+}

--- a/Assets/Scripts/GameSettings.cs.meta
+++ b/Assets/Scripts/GameSettings.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5cbf48422b0a4cfdbd774034e4107ef7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/MenuManager.cs
+++ b/Assets/Scripts/MenuManager.cs
@@ -1,0 +1,83 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.UI;
+
+public class MenuManager : MonoBehaviour
+{
+    public GameObject instructionsPanel;
+    public GameObject settingsPanel;
+    public GameObject mapPanel;
+    public Dropdown mapDropdown;
+    public Dropdown difficultyDropdown;
+
+    private List<string> levelScenes = new List<string>();
+
+    private void Start()
+    {
+        if (ProgressManager.Instance != null)
+        {
+            levelScenes = new List<string>(ProgressManager.Instance.LevelScenes);
+        }
+        PopulateMapDropdown();
+    }
+
+    private void PopulateMapDropdown()
+    {
+        if (mapDropdown == null)
+            return;
+
+        mapDropdown.ClearOptions();
+        List<string> options = new List<string>();
+        foreach (string scene in levelScenes)
+        {
+            if (ProgressManager.Instance == null || ProgressManager.Instance.IsUnlocked(scene))
+            {
+                options.Add(scene);
+            }
+        }
+        if (options.Count > 0)
+            mapDropdown.AddOptions(options);
+    }
+
+    public void Play()
+    {
+        if (mapDropdown == null || mapDropdown.options.Count == 0)
+            return;
+        string selected = mapDropdown.options[mapDropdown.value].text;
+        if (GameSettings.Instance != null)
+        {
+            GameSettings.Instance.selectedMap = selected;
+            if (difficultyDropdown != null)
+            {
+                GameSettings.Instance.difficulty = (Difficulty)difficultyDropdown.value;
+            }
+        }
+        SceneManager.LoadScene(selected);
+    }
+
+    public void ShowInstructions(bool visible)
+    {
+        if (instructionsPanel != null)
+            instructionsPanel.SetActive(visible);
+    }
+
+    public void ShowSettings(bool visible)
+    {
+        if (settingsPanel != null)
+            settingsPanel.SetActive(visible);
+    }
+
+    public void ShowMapSelect(bool visible)
+    {
+        if (mapPanel != null)
+            mapPanel.SetActive(visible);
+        if (visible)
+            PopulateMapDropdown();
+    }
+
+    public void Quit()
+    {
+        Application.Quit();
+    }
+}

--- a/Assets/Scripts/MenuManager.cs.meta
+++ b/Assets/Scripts/MenuManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2730e15a880541598297e5b1170e4727
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -64,6 +64,8 @@ public class PlayerController : MonoBehaviour
         if (!levelComplete && GameObject.FindGameObjectsWithTag("Enemy").Length == 0)
         {
             levelComplete = true;
+            if (ProgressManager.Instance != null)
+                ProgressManager.Instance.UnlockNext(SceneManager.GetActiveScene().name);
             if (LevelManager.Instance != null)
                 LevelManager.Instance.LoadNextLevel();
         }

--- a/Assets/Scripts/ProgressManager.cs
+++ b/Assets/Scripts/ProgressManager.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+public class ProgressManager : MonoBehaviour
+{
+    public static ProgressManager Instance { get; private set; }
+
+    private const string UnlockKey = "UnlockedIndex";
+
+    private List<string> levelScenes = new List<string>();
+    public List<string> LevelScenes => levelScenes;
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
+
+        for (int i = 0; i < SceneManager.sceneCountInBuildSettings; i++)
+        {
+            string path = SceneUtility.GetScenePathByBuildIndex(i);
+            string name = System.IO.Path.GetFileNameWithoutExtension(path);
+            if (name.StartsWith("Level"))
+            {
+                levelScenes.Add(name);
+            }
+        }
+    }
+
+    public bool IsUnlocked(string scene)
+    {
+        int index = levelScenes.IndexOf(scene);
+        if (index < 0) return false;
+        return index <= PlayerPrefs.GetInt(UnlockKey, 0);
+    }
+
+    public void UnlockNext(string currentScene)
+    {
+        int currentIndex = levelScenes.IndexOf(currentScene);
+        int unlocked = PlayerPrefs.GetInt(UnlockKey, 0);
+        if (currentIndex >= unlocked && currentIndex + 1 < levelScenes.Count)
+        {
+            PlayerPrefs.SetInt(UnlockKey, currentIndex + 1);
+            PlayerPrefs.Save();
+        }
+    }
+}

--- a/Assets/Scripts/ProgressManager.cs.meta
+++ b/Assets/Scripts/ProgressManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 86b1034cea7441acbad65ec5c7a64c96
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -6,6 +6,15 @@ EditorBuildSettings:
   serializedVersion: 2
   m_Scenes:
   - enabled: 1
+    path: Assets/Scenes/MainMenu.unity
+    guid: e67e1f6c5bd247129422df0d176c7e63
+  - enabled: 1
+    path: Assets/Scenes/Instructions.unity
+    guid: 2252306f033048dca8ab58516f9a50cd
+  - enabled: 1
+    path: Assets/Scenes/Settings.unity
+    guid: f1a937f1fc7f48dcb3fcfa7972d421ac
+  - enabled: 1
     path: Assets/Scenes/Bomber.unity
     guid: 2cda990e2423bbf4892e6590ba056729
   - enabled: 1


### PR DESCRIPTION
## Summary
- add simple MenuManager for scene navigation
- create GameSettings to persist difficulty and map choice
- track level unlocks with ProgressManager
- load next level and unlock progress in PlayerController
- add placeholder scenes for MainMenu, Instructions and Settings
- include new scenes in EditorBuildSettings

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842b21f2dd08322bc4a10aff92f43cf